### PR TITLE
BXMSDOC-1708: Resolved topics ID/link issue from BXMSDOC-1627 (part of User Guide mod)

### DIFF
--- a/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
@@ -1,4 +1,4 @@
-[[_creating_assets_proc_{chapter}]]
+[#creating_assets_proc_{context}]
 
 = Creating Assets
 

--- a/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-creating-proc.adoc
@@ -1,5 +1,4 @@
 [#creating_assets_proc_{context}]
-
 = Creating Assets
 
 You can create business processes, rules, DRL files, and other assets directly in Business Central and associate them with the projects that you create.

--- a/docs/product-user-guide/src/main/asciidoc/assets-projects-gloss.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-projects-gloss.adoc
@@ -1,4 +1,4 @@
-[[_assets_projects_gloss_{chapter}]]
+[#_assets_projects_gloss_{context}]
 
 = Projects
 

--- a/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/assets-types-ref.adoc
@@ -11,6 +11,7 @@ include::assets-business-rules-gloss.adoc[leveloffset=+1]
 
 include::assets-business-processes-gloss.adoc[leveloffset=+1]
 
+:context: assets-types-ref
 include::assets-projects-gloss.adoc[leveloffset=+1]
 
 include::assets-packages-gloss.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/business-central-con.adoc
@@ -11,7 +11,7 @@ Business Central integrates the following tools:
 * _Task client_ for managing and creating User Tasks (see <<_sect_user_tasks>>)
 * _Process Manager_ for managing process instances (see <<_sect_process_instances>>)
 * _Dashboard Builder_, the BAM component, for monitoring and reporting (see <<_chap_red_hat_jboss_dashboard_builder>>)
-* _Business Asset Manager_ for accessing the Knowledge Repository resources, building and deploying business assets (see <<_chap_project>>)
+* _Business Asset Manager_ for accessing the Knowledge Repository resources, building and deploying business assets (see xref:_assets_projects_gloss_chap-project[].)
 endif::BPMS[]
 
 ifdef::BRMS[]

--- a/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-assets.adoc
@@ -4,6 +4,7 @@ include::assets-con.adoc[]
 
 include::assets-types-ref.adoc[leveloffset=+1]
 
+:context: chap-assets
 include::assets-creating-proc.adoc[leveloffset=+1]
 
 include::assets-renaming-proc.adoc[leveloffset=+1]

--- a/docs/product-user-guide/src/main/asciidoc/chap-plug-in.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-plug-in.adoc
@@ -1,7 +1,7 @@
 
 Red Hat JBoss BPM Suite comes with a plug-in for Red Hat JBoss Developer Studio to provide support for the development of business processes in the Eclipse-based environment, such as debugging and testing. It also provides a graphical Process Designer for business process editing.
 
-Note that the repository structure follows the maven structure and is described in <<_chap_project>>.
+Note that the repository structure follows the maven structure and is described in xref:_assets_projects_gloss_chap-project[].
 
 For instructions on how to install and set up the plug-in, see the _{INSTALLATION_GUIDE}_.
 

--- a/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
@@ -1,4 +1,3 @@
-[[_chap_project]]
 
 :context: chap-project
 include::assets-projects-gloss.adoc[]

--- a/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
+++ b/docs/product-user-guide/src/main/asciidoc/chap-project.adoc
@@ -1,5 +1,6 @@
 [[_chap_project]]
 
+:context: chap-project
 include::assets-projects-gloss.adoc[]
 
 include::organizational-unit-con.adoc[leveloffset=+1]
@@ -32,6 +33,7 @@ include::project-REST-create-proc.adoc[leveloffset=+2]
 
 include::packages-create-proc.adoc[leveloffset=+1]
 
+:context: chap-project
 include::assets-creating-proc.adoc[leveloffset=+1]
 
 include::dependencies-add-proc.adoc[leveloffset=+1]


### PR DESCRIPTION
Corrected topic ID/links for the following topics, to allow topic reuse (this will be a universally adopted change at some point soon):
- assets-creating-proc.adoc
- assets-projects-gloss.adoc
- assets-types-ref.adoc
- chap-assets.adoc
- chap-project.adoc

JIRA: https://issues.jboss.org/browse/BXMSDOC-1708

Rendered output (the topics IDs for "Assets" and "Projects" sections now are correctly hidden, instead of being rendered as text):

- For BPMS: http://file.rdu.redhat.com/~sterobin/BXMSDOC-1708_BPMS/
- For BRMS: http://file.rdu.redhat.com/~sterobin/BXMSDOC-1708_BRMS/